### PR TITLE
#2 CustomDetails 무한 루프 오류 수정

### DIFF
--- a/src/main/java/last/lares/domain/auth/CustomUserDetails.java
+++ b/src/main/java/last/lares/domain/auth/CustomUserDetails.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -15,11 +14,20 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
     private final User user;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority(user.getUserRole().name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getUserPassword();
     }
 
     public String getUserId() {
@@ -52,15 +60,5 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
-    }
-
-    @Override
-    public String getUsername() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
     }
 }

--- a/src/main/java/last/lares/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/last/lares/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package last.lares.domain.auth.service;
+
+import last.lares.domain.auth.CustomUserDetails;
+import last.lares.domain.user.User;
+import last.lares.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        String userId = username;
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다 : " + userId));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/last/lares/domain/user/User.java
+++ b/src/main/java/last/lares/domain/user/User.java
@@ -25,6 +25,7 @@ public class User {
 
     private String userAddress;
 
+    @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     private LocalDateTime userCreatedAt;

--- a/src/main/java/last/lares/domain/user/User.java
+++ b/src/main/java/last/lares/domain/user/User.java
@@ -26,7 +26,7 @@ public class User {
     private String userAddress;
 
     @Enumerated(EnumType.STRING)
-    private UserRole userRole;
+    private UserRole userRole = UserRole.ROLE_USER;
 
     private LocalDateTime userCreatedAt;
 }


### PR DESCRIPTION
**발견된 오류**
- UserDetailsService 의 부재
  - auth 도메인 내 service 에 CustomUserDetailsService.java 생성
- 올바르지 못한 CustomUserDetails 메서드 반환 값
  - user 의 userId. userPassword 등 올바른 로그인 대조 값 반환하도록 수정
- JPA 에 의한 DEFAULT 'ROLE_USER' 설정 무효 및 Enum 매핑 실패
  - 필드 선언과 동시에 할당함으로써 해결
  - @Enumerated 어노테이션을 통해 문자열 매핑 설정

