### PR TITLE
#2 인증된 사용자 정보 누락 오류 수정 #9

### DIFF
--- a/src/main/java/last/lares/global/config/filter/JwtFilter.java
+++ b/src/main/java/last/lares/global/config/filter/JwtFilter.java
@@ -56,7 +56,7 @@ public class JwtFilter extends OncePerRequestFilter {
                     .build();
 
             CustomUserDetails userDetails = new CustomUserDetails(user);
-            Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null);
+            Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
             SecurityContextHolder.getContext().setAuthentication(auth);
 


### PR DESCRIPTION
**발견된 오류**
- 올바른 토큰 기입에도 403 Forbidden 반환
  - SecurityContextHolder 내 누락된 사용자의 인증 정보 기입

기존 Pull Request 에서 불필요한 파일이 함께 합병되어 수정하였습니다.